### PR TITLE
Pin Erlang to v23

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-erlang 25.1
-elixir 1.14.3
+erlang 23.0.2
+elixir 1.11.3
 nodejs 22.13.0
 postgres 15

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: cd $HOME && POOL_SIZE=2 mix do ecto.migrate
+release: POOL_SIZE=2 mix ecto.migrate
 web: NODE=$(mix phx.gen.secret) mix phx.server

--- a/app.json
+++ b/app.json
@@ -54,7 +54,7 @@
   "stack": "heroku-20",
   "buildpacks": [
     {
-      "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz"
+      "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
     },
     {
       "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"

--- a/app.json
+++ b/app.json
@@ -54,7 +54,7 @@
   "stack": "heroku-20",
   "buildpacks": [
     {
-      "url": "https://github.com/HashNuke/heroku-buildpack-elixir#b9092d471ebb0163dbf1bf733b719cf1e31c8f64"
+      "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz"
     },
     {
       "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"

--- a/app.json
+++ b/app.json
@@ -51,7 +51,7 @@
   "scripts": {
     "postdeploy": "POOL_SIZE=2 mix ecto.migrate"
   },
-  "stack": "heroku-22",
+  "stack": "heroku-20",
   "buildpacks": [
     {
       "url": "https://github.com/HashNuke/heroku-buildpack-elixir"

--- a/app.json
+++ b/app.json
@@ -54,7 +54,7 @@
   "stack": "heroku-20",
   "buildpacks": [
     {
-      "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
+      "url": "https://github.com/HashNuke/heroku-buildpack-elixir#b9092d471ebb0163dbf1bf733b719cf1e31c8f64"
     },
     {
       "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"

--- a/app.json
+++ b/app.json
@@ -54,10 +54,7 @@
   "stack": "heroku-20",
   "buildpacks": [
     {
-      "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
-    },
-    {
-      "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"
+      "url": "https://github.com/HashNuke/heroku-buildpack-elixir#378538d1f619abbb6fe318b9bed719cb18d42955"
     }
   ]
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-import Config
+use Mix.Config
 
 config :chat_api,
   environment: Mix.env(),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-import Config
+use Mix.Config
 
 database_url = System.get_env("DATABASE_URL") || "ecto://postgres:postgres@localhost/chat_api_dev"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-import Config
+use Mix.Config
 
 database_url = System.get_env("DATABASE_URL") || "ecto://postgres:postgres@localhost/chat_api_dev"
 pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-import Config
+use Mix.Config
 
 # Configure your database
 #

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -3,7 +3,7 @@ elixir_version=1.11.3
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=OTP-23.3.4
+erlang_version=OTP-23.3
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,10 +1,10 @@
 # Elixir version
-elixir_version=1.12.0
+elixir_version=1.14.5
 
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=23.3.4.1
+erlang_version=23.3.4
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -4,7 +4,7 @@ elixir_version=1.12.0
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=23.0.3
+erlang_version=23.3.4.1
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -3,7 +3,7 @@ elixir_version=1.11.3
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=OTP-23.3.4.20
+erlang_version=OTP-23.3.4
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,7 +1,6 @@
 # Elixir version
 elixir_version=1.14.5
 
-
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
 erlang_version=23.3.4

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -4,7 +4,7 @@ elixir_version=1.12.0
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=23.3.4.1
+erlang_version=23.0.3
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,9 +1,10 @@
 # Elixir version
-elixir_version=1.11.3
+elixir_version=1.12.0
+
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=OTP-23.3
+erlang_version=23.3.4.1
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -3,7 +3,7 @@ elixir_version=1.11.3
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=23.0.2
+erlang_version=OTP-23.3.4.20
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,9 +1,9 @@
 # Elixir version
-elixir_version=1.14.3
+elixir_version=1.11.3
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=25.1
+erlang_version=23.0.2
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true


### PR DESCRIPTION
With Erlang v24, `:crypto.hmac(:sha256, key, data)` was deprecated and replaced with `:crypto.mac(:hmac, :sha256, key, data)` — we're getting Heroku build errors because of this.

```
ID 8919a1a1-0a0c-4e91-bbea-87d956f26542
chat_api: generated priv/static/swagger.json
06:28:34.294 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
06:28:34.294 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
06:28:34.485 [error] GenServer #PID<0.425.0> terminating
** (stop) {%UndefinedFunctionError{module: :crypto, function: :hmac, arity: 3, reason: nil, message: nil}, []}
Last message: nil
State: Postgrex.Protocol
06:28:34.485 [error] GenServer #PID<0.426.0> terminating
** (stop) {%UndefinedFunctionError{module: :crypto, function: :hmac, arity: 3, reason: nil, message: nil}, []}
Last message: nil
State: Postgrex.Protocol
06:28:34.519 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
06:28:34.519 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
06:28:34.573 [error] GenServer #PID<0.441.0> terminating
** (stop) {%UndefinedFunctionError{module: :crypto, function: :hmac, arity: 3, reason: nil, message: nil}, []}
Last message: nil
State: Postgrex.Protocol
06:28:34.577 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
06:28:34.581 [error] GenServer #PID<0.440.0> terminating
** (stop) {%UndefinedFunctionError{module: :crypto, function: :hmac, arity: 3, reason: nil, message: nil}, []}
Last message: nil
State: Postgrex.Protocol
** (EXIT from #PID<0.96.0>) shutdown
```

I was thinking that we can stay on Erlang v23 and Heroku 20 despite the deprecation, and... _après moi, le déluge_.

Partially reverts https://github.com/iterative/papercups/commit/10ec0eecb4da7bf964a7acea2bcc59fccdf98cdc